### PR TITLE
Pull eDistantObject as Git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *~
 *.sw[o-p]
 .DS_Store
-Submodules/
 EarlGrey.xcodeproj/xcuserdata

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Submodules/eDistantObject"]
+	path = Submodules/eDistantObject
+	url = https://github.com/google/eDistantObject

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use, please clone the `earlgrey2` branch with its submodules:
 git clone -b earlgrey2 https://github.com/google/EarlGrey.git
 
 // Download any dependencies
-sh Scripts/download_deps.sh
+git submodule update --init --recursive
 ```
 
 # EarlGrey 2.0

--- a/Scripts/download_deps.sh
+++ b/Scripts/download_deps.sh
@@ -1,8 +1,0 @@
-# Always call this from within the EarlGrey repository.
-EARLGREY_ROOT_DIR=$(git rev-parse --show-toplevel)
-if [ -d $EARLGREY_ROOT_DIR/"Submodules" ]; then
-    echo "Already cloned submodules. Delete the submodules directory to re-clone submodules."
-else
-    echo "Submodules does not exist, cloning submodules."
-    git clone https://github.com/google/eDistantObject $EARLGREY_ROOT_DIR/Submodules/eDistantObject
-fi

--- a/Tests/Functional/README.md
+++ b/Tests/Functional/README.md
@@ -7,7 +7,7 @@ have been correctly added to the repository:
 ```
 git clone -b earlgrey2 https://github.com/google/EarlGrey.git
 
-sh Scripts/download_deps.sh
+git submodule update --init --recursive
 ```
 
 Once the EarlGrey targets are building,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -40,7 +40,7 @@ git clone -b earlgrey2 https://github.com/google/EarlGrey.git
 
 // Download any dependencies. Run this command from the EarlGrey/ root directory
 // as it will download the submodules in the root of the Git repository it is called from.
-sh Scripts/download_deps.sh
+git submodule update --init --recursive
 ```
 
 On doing so, your folder structure inside the EarlGrey repository should look


### PR DESCRIPTION
Get rid of `download_deps.sh` script which pulls NON-VERSIONED dependencies breaking stuff when upstream updates.